### PR TITLE
eslintによるエラーの対応

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,39 +1,25 @@
 module.exports = {
-	'env': {
-		'browser': true,
-		'es2021': true,
-		'node': true
+	env: {
+		browser: true,
+		es2021: true,
+		node: true,
 	},
-	'extends': [
+	extends: [
 		'eslint:recommended',
 		'plugin:@typescript-eslint/recommended',
-		'plugin:react/recommended'
+		'plugin:react/recommended',
 	],
-	'parser': '@typescript-eslint/parser',
-	'parserOptions': {
-		'ecmaVersion': 'latest',
-		'sourceType': 'module'
+	parser: '@typescript-eslint/parser',
+	parserOptions: {
+		ecmaVersion: 'latest',
+		sourceType: 'module',
 	},
-	'plugins': [
-		'@typescript-eslint',
-		'react'
-	],
-	'rules': {
-		'indent': [
-			'error',
-			'tab'
-		],
-		'linebreak-style': [
-			'error',
-			'unix'
-		],
-		'quotes': [
-			'error',
-			'single'
-		],
-		'semi': [
-			'error',
-			'always'
-		]
-	}
+	plugins: ['@typescript-eslint', 'react'],
+	rules: {
+		'react/jsx-uses-react': 'off',
+		'react/react-in-jsx-scope': 'off',
+		'linebreak-style': ['error', 'unix'],
+		quotes: ['error', 'single'],
+		semi: ['error', 'always'],
+	},
 };

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "arrowParens": "always"
+}


### PR DESCRIPTION
## issue
#59

## 概要
コードが自動整形されるよう.prettierrc.jsonを追加
eslintのルールを変更(indentのルールを削除、react/jsx-in-jsx-scopeを無効化)

indentのルールはprettierとうまく噛み合わなかったため削除しました(Expected indentation of 6 tabs but found 7.
といったeslintエラーをprettierの自動整形では解決できない)。
[react/jsx-in-jsx-scopeについて](https://ja.legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#eslint)