### PR TITLE
【スライド画面】スワイプ、タップでの表示切り替え

### DIFF
--- a/src/screens/Slide/UI/Components/PanGesture.tsx
+++ b/src/screens/Slide/UI/Components/PanGesture.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { FC, ReactNode } from 'react';
+import { StyleSheet } from 'react-native';
+import {
+  GestureHandlerRootView,
+  HandlerStateChangeEvent,
+  PanGestureHandler,
+} from 'react-native-gesture-handler';
+
+interface PanGestureProps {
+  children: ReactNode;
+  page: number;
+  handlePageChange: (page: number) => void;
+}
+
+export const PanGesture: FC<PanGestureProps> = ({ children, page, handlePageChange }) => {
+  const velocityThreshold = 0.3;
+  const directionalOffsetThreshold = 80;
+
+  const isValidSwipe = (velocity: number, directionalOffset: number) => {
+    return (
+      Math.abs(velocity) > velocityThreshold &&
+      Math.abs(directionalOffset) < directionalOffsetThreshold
+    );
+  };
+
+  const onPanGestureEvent = (event: HandlerStateChangeEvent<any>) => {
+    const { nativeEvent } = event;
+    if (Math.abs(nativeEvent.velocityY) > 300) {
+      return;
+    }
+    if (!isValidSwipe(nativeEvent.velocityX, nativeEvent.translationX)) {
+      return;
+    }
+
+    if (nativeEvent.velocityX > 0) {
+      handlePageChange(page - 1);
+    } else {
+      handlePageChange(page + 1);
+    }
+  };
+
+  return (
+    <GestureHandlerRootView style={styles.container}>
+      <PanGestureHandler onActivated={onPanGestureEvent}>{children}</PanGestureHandler>
+    </GestureHandlerRootView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+  },
+});

--- a/src/screens/Slide/UI/SlideCon.tsx
+++ b/src/screens/Slide/UI/SlideCon.tsx
@@ -31,6 +31,7 @@ export const SlideCon: FC<SlideConProps> = ({ navigation, route }) => {
     if (page >= 0 && page <= pageTotal - 1) {
       if (isSpeaking) handleSpeechStop();
       setPage(page);
+      setIsFront(true);
     }
   };
 
@@ -52,7 +53,7 @@ export const SlideCon: FC<SlideConProps> = ({ navigation, route }) => {
       });
     }
   };
-  
+
   useEffect(() => {
     const blurUnsubscribe = navigation.addListener('blur', handleSpeechStop);
     const beforeRemoveUnsubscribe = navigation.addListener('beforeRemove', handleSpeechStop);
@@ -64,13 +65,13 @@ export const SlideCon: FC<SlideConProps> = ({ navigation, route }) => {
 
   return (
     <SlidePre
-      handleGoBack={handleGoBack}
       word_list={data}
       page={page}
-      handlePageChange={handlePageChange}
       isFront={isFront}
-      handleFlip={handleFlip}
       isSpeaking={isSpeaking}
+      handleGoBack={handleGoBack}
+      handleFlip={handleFlip}
+      handlePageChange={handlePageChange}
       handlePressSpeaker={handlePressSpeaker}
     />
   );

--- a/src/screens/Slide/UI/SlidePre.tsx
+++ b/src/screens/Slide/UI/SlidePre.tsx
@@ -2,6 +2,7 @@ import { AntDesign, Ionicons } from '@expo/vector-icons';
 import { FC } from 'react';
 import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { WordDef } from '../../../atom/FlashCardsDataState';
+import { PanGesture } from './Components/PanGesture';
 import { SlideButton } from './Components/SlideButton';
 
 interface SlidePreProps {
@@ -37,49 +38,50 @@ export const SlidePre: FC<SlidePreProps> = (props) => {
           <Text style={styles.headline_text}>意味・例文</Text>
         )}
       </View>
-
-      <View style={styles.slide}>
-        <View style={styles.content}>
-          {/* 表なら単語、裏なら意味・例文 */}
-          {isFront ? (
-            <>
-              <Text style={styles.content_text}>{word_list[page].name}</Text>
-              <TouchableOpacity
-                onPress={() => handlePressSpeaker(word_list[page].name)}
-                style={styles.speakerContainer}
-              >
-                <Ionicons
-                  name="volume-medium-outline"
-                  size={32}
-                  style={isSpeaking ? styles.green : styles.lightGray}
-                />
-              </TouchableOpacity>
-            </>
-          ) : (
-            <>
-              <ScrollView
-                showsVerticalScrollIndicator={false}
-                contentContainerStyle={styles.scrollContainer}
-              >
-                <View style={styles.scrollContent}>
-                  <Text style={styles.content_text}>意味: {word_list[page].mean}</Text>
-                  <Text style={styles.content_text}>例文: {word_list[page].example}</Text>
-                </View>
-              </ScrollView>
-              <TouchableOpacity
-                onPress={() => handlePressSpeaker(word_list[page].example)}
-                style={styles.speakerContainer}
-              >
-                <Ionicons
-                  name="volume-medium-outline"
-                  size={32}
-                  style={isSpeaking ? styles.green : styles.lightGray}
-                />
-              </TouchableOpacity>
-            </>
-          )}
+      <PanGesture page={page} handlePageChange={handlePageChange}>
+        <View style={styles.slide}>
+          <TouchableOpacity onPress={handleFlip} style={styles.content}>
+            {/* 表なら単語、裏なら意味・例文 */}
+            {isFront ? (
+              <>
+                <Text style={styles.content_text}>{word_list[page].name}</Text>
+                <TouchableOpacity
+                  onPress={() => handlePressSpeaker(word_list[page].name)}
+                  style={styles.speakerContainer}
+                >
+                  <Ionicons
+                    name="volume-medium-outline"
+                    size={32}
+                    style={isSpeaking ? styles.green : styles.lightGray}
+                  />
+                </TouchableOpacity>
+              </>
+            ) : (
+              <>
+                <ScrollView
+                  showsVerticalScrollIndicator={false}
+                  contentContainerStyle={styles.scrollContainer}
+                >
+                  <View style={styles.scrollContent}>
+                    <Text style={styles.content_text}>意味: {word_list[page].mean}</Text>
+                    <Text style={styles.content_text}>例文: {word_list[page].example}</Text>
+                  </View>
+                </ScrollView>
+                <TouchableOpacity
+                  onPress={() => handlePressSpeaker(word_list[page].example)}
+                  style={styles.speakerContainer}
+                >
+                  <Ionicons
+                    name="volume-medium-outline"
+                    size={32}
+                    style={isSpeaking ? styles.green : styles.lightGray}
+                  />
+                </TouchableOpacity>
+              </>
+            )}
+          </TouchableOpacity>
         </View>
-      </View>
+      </PanGesture>
 
       <View style={styles.pagenation}>
         <View>


### PR DESCRIPTION
## issue
#78

## 概要
スワイプでページ切り替え
タップでカードの表裏切り替え
ページ切り替え時、常にカード表を表示